### PR TITLE
Fix for SQL insert error

### DIFF
--- a/subsonic-main/src/main/java/net/sourceforge/subsonic/dao/AlbumDao.java
+++ b/subsonic-main/src/main/java/net/sourceforge/subsonic/dao/AlbumDao.java
@@ -147,7 +147,7 @@ public class AlbumDao extends AbstractDao {
 
         if (n == 0) {
 
-            update("insert into album (" + COLUMNS + ") values (" + questionMarks(COLUMNS) + ")", null, album.getPath(),
+            update("insert into album (" + COLUMNS + ", description, reader) values (" + questionMarks(COLUMNS) + ", ?, ?)", null, album.getPath(),
                    album.getName(), album.getArtist(), album.getSongCount(), album.getDurationSeconds(),
                    album.getCoverArtPath(), album.getYear(), album.getGenre(), album.getPlayCount(), album.getLastPlayed(),
                    album.getComment(), album.getCreated(), album.getLastScanned(), album.isPresent(), album.getFolderId(), lang, desc, reader);


### PR DESCRIPTION
COLUMNS hasn't been updated to include description or reader causing an SQL error to be thrown. I wasn't sure if it was safe to just update COLUMNS so I just updated the query that was causing the error.