### PR TITLE
updated pom file as codehaus no longer works and has been moved to th…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,10 +53,6 @@
             <name>Local Repository 2</name>
             <url>file:../repo</url>
         </pluginRepository>
-        <pluginRepository>
-            <id>Codehaus Repository</id>
-            <url>http://repository.codehaus.org/</url>
-        </pluginRepository>
     </pluginRepositories>
 
     <scm>


### PR DESCRIPTION
 updated pom file as codehaus no longer works and has been moved to the maven central. The project will not build with the refernece to codehaus.org.  I have verified this works and project builds and works after being deployed.
